### PR TITLE
Fix how Metal delegate options are passed to TFLGpuDelegateCreate.

### DIFF
--- a/Packages/com.github.asus4.tflite/Runtime/MetalDelegate.cs
+++ b/Packages/com.github.asus4.tflite/Runtime/MetalDelegate.cs
@@ -39,13 +39,14 @@ namespace TensorFlowLite
         {
             public bool allowPrecisionLoss;
             public WaitType waitType;
+            public bool enableQuantization;
         }
 
         public TfLiteDelegate Delegate { get; private set; }
 
         public MetalDelegate(Options options)
         {
-            Delegate = TFLGpuDelegateCreate(options);
+            Delegate = TFLGpuDelegateCreate(ref options);
         }
 
         public void Dispose()
@@ -63,7 +64,7 @@ namespace TensorFlowLite
 #endif // UNITY_IOS && !UNITY_EDITOR
 
         [DllImport(TensorFlowLibraryGPU)]
-        private static extern unsafe TfLiteDelegate TFLGpuDelegateCreate(Options delegateOptions);
+        private static extern unsafe TfLiteDelegate TFLGpuDelegateCreate(ref Options delegateOptions);
 
         [DllImport(TensorFlowLibraryGPU)]
         private static extern unsafe void TFLGpuDelegateDelete(TfLiteDelegate gpuDelegate);


### PR DESCRIPTION
The C API is defined as:

`TfLiteDelegate* TFLGpuDelegateCreate(const TFLGpuDelegateOptions* options);`

but the current C# extern declaration tries to pass the options by value, not by pointer. This by chance happens to work with the default value of `options.allowPrecisionLoss = false` because it is the first value in the struct and interpreted as an `IntPtr.Zero`.
This commit fixes the extern declaration to pass options by pointer and also adds the missing `enableQuantization` field to the options struct.