### PR TITLE
Fix how GL delegate options are passed to TfLiteGpuDelegateV2Create.

### DIFF
--- a/Packages/com.github.asus4.tflite/Runtime/GlDelegate.cs
+++ b/Packages/com.github.asus4.tflite/Runtime/GlDelegate.cs
@@ -43,7 +43,7 @@ namespace TensorFlowLite
         public GlDelegate()
         {
             Options options = TfLiteGpuDelegateOptionsV2Default();
-            Delegate = TfLiteGpuDelegateV2Create(options);
+            Delegate = TfLiteGpuDelegateV2Create(ref options);
         }
 
         public void Dispose()
@@ -59,7 +59,7 @@ namespace TensorFlowLite
         private static extern unsafe Options TfLiteGpuDelegateOptionsV2Default();
 
         [DllImport(TensorFlowLibraryGPU)]
-        private static extern unsafe TfLiteDelegate TfLiteGpuDelegateV2Create(Options options);
+        private static extern unsafe TfLiteDelegate TfLiteGpuDelegateV2Create(ref Options options);
 
         [DllImport(TensorFlowLibraryGPU)]
         private static extern unsafe void TfLiteGpuDelegateV2Delete(TfLiteDelegate gpuDelegate);


### PR DESCRIPTION
The C API is defined as:

`TfLiteDelegate* TfLiteGpuDelegateV2Create(const TfLiteGpuDelegateOptionsV2* options);`

but the current C# extern declaration tries to pass the options by value, not by pointer. This by chance happens to work with the default value of `options.isPrecisionLossAllowed = 0` because it is the first value in the struct and interpreted as an `IntPtr.Zero`.
This commit fixes the extern declaration to pass options by pointer.