### PR TITLE
Update .gitattributes for .tflite files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,4 +10,4 @@
 **/TensorFlowLiteCCoreML.framework/TensorFlowLiteCCoreML filter=lfs diff=lfs merge=lfs -text
 
 # Big TFLite models
-Assets/StreamingAssets/*.tflite filter=lfs diff=lfs merge=lfs -text
+*.tflite filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Minor tweak to .gitattributes - wouldn't it be preferable to set .gitattributes for all .tflite files?

I noticed because SourceTree warned me about adding large files when I was experimenting with adding new .tflite models to the project.

Specifically, the models in these folders were not added to LFS:

- Assets\StreamingAssets\mediapipe
- Assets\StreamingAssets\meet
- And some models in Assets\StreamingAssets before this repo started using LFS

----

(It should be possible to migrate non-LFS files to LFS, but I didn't bother with this step here.)

https://stackoverflow.com/questions/42963854/list-files-not-tracked-by-git-lfs
https://stackoverflow.com/a/57820265/