### PR TITLE
Release model GCHandle in interpreter

### DIFF
--- a/Packages/com.github.asus4.tflite/Runtime/Interpreter.cs
+++ b/Packages/com.github.asus4.tflite/Runtime/Interpreter.cs
@@ -58,6 +58,7 @@ namespace TensorFlowLite
             GCHandle modelDataHandle = GCHandle.Alloc(modelData, GCHandleType.Pinned);
             IntPtr modelDataPtr = modelDataHandle.AddrOfPinnedObject();
             model = TfLiteModelCreate(modelDataPtr, modelData.Length);
+            modelDataHandle.Free();
             if (model == IntPtr.Zero) throw new Exception("Failed to create TensorFlowLite Model");
 
             this.options = options ?? new InterpreterOptions();


### PR DESCRIPTION
Add `GCHandle.Free()` in interpreter.cs

Probably this should be fixed in the official [TensorFlowLitePlugin](https://github.com/tensorflow/tensorflow/blob/f959fe4761b7ea3b3e474652e04799e9f6e09f06/tensorflow/lite/experimental/examples/unity/TensorFlowLitePlugin/Assets/TensorFlowLite/SDK/Scripts/Interpreter.cs) as well.

Fix #145