### PR TITLE
chore: update readme typos, remove obsolete instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,11 @@ Pre-built libraries are included. If you want to build the latest TFLite,
 
   ```sh
   # Update iOS, Andoid and macOS
-  ./build_tflte.py --tfpath ../tensorflow -ios -android -macos
+  ./build_tflite.py --tfpath ../tensorflow -ios -android -macos
 
   # Build with XNNPACK
-  ./build_tflte.py --tfpath ../tensorflow -macos -xnnpack
+  ./build_tflite.py --tfpath ../tensorflow -macos -xnnpack
   ```
-
-- To build macOS Metal Delegate on TensorFlow v2.3.0 or later, You need to apply following changes [the issue](https://github.com/tensorflow/tensorflow/issues/41039#issuecomment-664701908)
 
 ## TIPS
 


### PR DESCRIPTION
Realized there was a typo in the command to build tflite.

Also, it seems like the instruction was irrelevant due to changes in #136 