### PR TITLE
Update build command

### DIFF
--- a/build_tflite.py
+++ b/build_tflite.py
@@ -32,7 +32,7 @@ def build_mac(enable_xnnpack = False):
     # Main
     option_xnnpack = 'true' if enable_xnnpack else 'false'
     run_cmd(f'bazel build --config=macos --cpu=darwin -c opt --define tflite_with_xnnpack={option_xnnpack} tensorflow/lite/c:tensorflowlite_c')
-    run_cmd(f'bazel build --config=macos --cpu=darwin_arm64 -c opt --define tflite_with_xnnpack={option_xnnpack} tensorflow/lite/c:tensorflowlite_c')
+    run_cmd(f'bazel build --config=macos_arm64 --cpu=darwin_arm64 -c opt --define tflite_with_xnnpack={option_xnnpack} tensorflow/lite/c:tensorflowlite_c')
     dylib_bin_path = 'bin/tensorflow/lite/c/libtensorflowlite_c.dylib'
     run_cmd(f'lipo -create -output {PLUGIN_PATH}/macOS/libtensorflowlite_c.dylib bazel-out/darwin-opt/{dylib_bin_path} bazel-out/darwin_arm64-opt/{dylib_bin_path}')
 

--- a/build_tflite.py
+++ b/build_tflite.py
@@ -111,7 +111,7 @@ if __name__ == '__main__':
                         help = 'Build iOS')
     parser.add_argument('-android', action = "store_true", default = False,
                         help = 'Build Android')
-    parser.add_argument('-xnnpack', action = "store_true", default = False,
+    parser.add_argument('-xnnpack', action = "store_true", default = True,
                         help = 'Build with XNNPACK')
 
     args = parser.parse_args()

--- a/build_tflite.py
+++ b/build_tflite.py
@@ -13,7 +13,9 @@ TENSORFLOW_PATH=''
 def run_cmd(cmd):
     print(cmd)
     args = shlex.split(cmd)
-    return subprocess.check_output(args, cwd=TENSORFLOW_PATH, universal_newlines=True, shell=True)
+    # TODO: this is not working on Linux.
+    # return subprocess.check_output(args, cwd=TENSORFLOW_PATH, universal_newlines=True, shell=True)
+    subprocess.call(args, cwd=TENSORFLOW_PATH)
 
 def copy(from_tf, to_unity):
     subprocess.call(['cp', '-vf', f'{TENSORFLOW_PATH}/{from_tf}', f'{PLUGIN_PATH}/{to_unity}'])


### PR DESCRIPTION
Partially fixes for the issue #213 and #212

I have looked at this issue a bit and it seems to be a combined problem.

## Addressed in the PR

- Wait for finish bazel compiling by using `subprocess.call`

## Issues in TensorFlow / macOS

### iOS build
- Error on TensorFlow `v2.8` && macOS `12.3 or later`: `env: python: No such file or directory`
   - Python2 is removed in macOS 12.3. it is addressed in TF2.9.
- Error on TensorFlow `v2.9` / `master` : `thread-local storage is not supported for the current target`
  - See https://github.com/tensorflow/tensorflow/issues/55322

### macOS metal delegate build
- Error on TensorFlow `v2.8` && macOS `12.3 or later`: `env: python: No such file or directory
   - Python2 is removed in macOS 12.3. it is addressed in TF2.9.
- Error on TensorFlow `v2.9`: `Undefined symbols for architecture x86_64:`
  - I suppose this is a specific issue on the arm64 CPU. But changes in https://github.com/tensorflow/tensorflow/issues/41039#issuecomment-664701908  did not work for me.