### PR TITLE
fix/set interpreter options pointer to null in dispose()

### DIFF
--- a/Packages/com.github.asus4.tflite/Runtime/InterpreterOptions.cs
+++ b/Packages/com.github.asus4.tflite/Runtime/InterpreterOptions.cs
@@ -68,6 +68,7 @@ namespace TensorFlowLite
             if (nativePtr != IntPtr.Zero)
             {
                 TfLiteInterpreterOptionsDelete(nativePtr);
+                nativePtr = IntPtr.Zero;
             }
             foreach (var gpuDelegate in delegates)
             {


### PR DESCRIPTION
This patch fix the following situation.

```
var sharedOptions = new InterpreterOptions();
var interpreterA = new Interpreter(..., sharedOptions);
var interpreterB = new Interpreter(..., sharedOptions);

interpreterA.Dispose(); // try to delete sharedOptions but the pointer was not null
interpreterB.Dispose(); // try to delete sharedOptions again -> error!
```

By the way, It might be a good idea to restrict the use of cleanup to the managed resources like [onnxruntime C# APIs](https://github.com/microsoft/onnxruntime/blob/master/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs#L1081).