### PR TITLE
Add support for building the native plugins by CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,171 @@
+version: 2.1
+
+orbs:
+  win: circleci/windows@5.0
+  android: circleci/android@2.1.2
+
+parameters:
+  tf-repository:
+    type: string
+    default: "git@github.com:tensorflow/tensorflow.git"
+  tf-branch:
+    type: string
+    default: "v2.10.0"
+
+jobs:
+  build-mac:
+    macos:
+      xcode: 12.5.1
+    steps:
+      - checkout
+      - run:
+          name: Install Bazelisk
+          command: |
+            npm install -g @bazel/bazelisk  
+      - run:
+          name: Install NumPy
+          command: |
+            pip3 install numpy
+      - run:
+          name: Download TensorFlow
+          command: |
+            git clone --depth 1 << pipeline.parameters.tf-repository >> --branch << pipeline.parameters.tf-branch >> ../tensorflow
+      - run:
+          name: Build TensorFlow Lite for macOS
+          command: |
+            python3 build_tflite.py -macos
+      - run:
+          name: Compress Artifacts
+          command: tar -cvzf macOS.tar Packages/com.github.asus4.tflite/Plugins/macOS
+      - store_artifacts:
+          path: macOS.tar
+  build-windows:
+    executor:
+      name: win/default
+    steps:
+      - checkout
+      - run:
+          name: Install Bazelisk
+          command: |
+            choco install bazelisk -y
+      - run:
+          name: Install NumPy
+          command: |
+            pip install numpy
+      - run:
+          name: Download TensorFlow
+          command: |
+            git clone --depth 1 << pipeline.parameters.tf-repository >> --branch << pipeline.parameters.tf-branch >> ../tensorflow
+      - run:
+          name: Build TensorFlow Lite for Windows
+          command: |
+            python build_tflite.py -windows
+      - run:
+          name: Compress Artifacts
+          command: tar -cvzf Windows.tar Packages/com.github.asus4.tflite/Plugins/Windows
+      - store_artifacts:
+          path: Windows.tar
+  build-linux:
+    machine:
+      image: ubuntu-2004:202010-01
+    steps:
+      - checkout
+      - run:
+          name: Install GLES dependencies
+          command: |
+            sudo apt-get update
+            sudo apt-get install --no-install-recommends -y libgles2-mesa-dev libdrm-dev
+      - run:
+          name: Install Bazelisk
+          command: |
+            npm install -g @bazel/bazelisk  
+      - run:
+          name: Install NumPy
+          command: |
+            pip3 install numpy
+      - run:
+          name: Download TensorFlow
+          command: |
+            git clone --depth 1 << pipeline.parameters.tf-repository >> --branch << pipeline.parameters.tf-branch >> ../tensorflow
+      - run:
+          name: Build TensorFlow Lite for Linux
+          command: |
+            python3 build_tflite.py -linux
+      - run:
+          name: Compress Artifacts
+          command: tar -cvzf Linux.tar Packages/com.github.asus4.tflite/Plugins/Linux
+      - store_artifacts:
+          path: Linux.tar
+  build-ios:
+    macos:
+      xcode: 12.5.1
+    steps:
+      - checkout
+      - run:
+          name: Install Bazelisk
+          command: |
+            npm install -g @bazel/bazelisk  
+      - run:
+          name: Install NumPy
+          command: |
+            pip3 install numpy
+      - run:
+          name: Download TensorFlow
+          command: |
+            git clone --depth 1 << pipeline.parameters.tf-repository >> --branch << pipeline.parameters.tf-branch >> ../tensorflow
+      - run:
+          name: Build TensorFlow Lite for iOS
+          command: |
+            mv ../tensorflow/tensorflow/lite/ios/BUILD.apple ../tensorflow/tensorflow/lite/ios/BUILD
+            mv ../tensorflow/tensorflow/lite/objc/BUILD.apple ../tensorflow/tensorflow/lite/objc/BUILD
+            mv ../tensorflow/tensorflow/lite/swift/BUILD.apple ../tensorflow/tensorflow/lite/swift/BUILD
+            python3 build_tflite.py -ios
+      - run:
+          name: Compress Artifacts
+          command: tar -cvzf iOS.tar Packages/com.github.asus4.tflite/Plugins/iOS
+      - store_artifacts:
+          path: iOS.tar
+  build-android:
+    machine:
+      image: android:202102-01
+    environment:
+      ANDROID_SDK_API_LEVEL: 23
+      ANDROID_NDK_API_LEVEL: 21
+      ANDROID_BUILD_TOOLS_VERSION: 30.0.3
+    steps:
+      - checkout
+      - run:
+          name: Install Bazelisk
+          command: |
+            npm install -g @bazel/bazelisk  
+      - run:
+          name: Install NumPy
+          command: |
+            pip3 install numpy
+      - run:
+          name: Download TensorFlow
+          command: |
+            git clone --depth 1 << pipeline.parameters.tf-repository >> --branch << pipeline.parameters.tf-branch >> ../tensorflow
+      - run:
+          name: Build TensorFlow Lite for Android
+          command: |
+            # For gpu-api-delegate branch
+            # sed -i -e 's/libtensorflowlite_gpu_delegate.so/libtensorflowlite_gpu_api_delegate.so/' ../tensorflow/tensorflow/lite/delegates/gpu/BUILD 
+            # sed -i -e 's/\":delegate\"/\"\/\/tensorflow\/lite\/delegates\/gpu\/cl:gpu_api_delegate\"/' ../tensorflow/tensorflow/lite/delegates/gpu/BUILD
+            export ANDROID_SDK_HOME=$ANDROID_HOME
+            python3 build_tflite.py -android
+      - run:
+          name: Compress Artifacts
+          command: tar -cvzf Android.tar Packages/com.github.asus4.tflite/Plugins/Android
+      - store_artifacts:
+          path: Android.tar
+
+workflows:
+  version: 2
+  build-all:
+    jobs:
+      - build-mac
+      - build-windows
+      - build-linux
+      - build-ios
+      - build-android

--- a/build_tflite.py
+++ b/build_tflite.py
@@ -5,7 +5,9 @@ import glob
 import os
 import platform
 import shlex
+import shutil
 import subprocess
+import sys
 
 PLUGIN_PATH=f'{os.getcwd()}/Packages/com.github.asus4.tflite/Plugins'
 TENSORFLOW_PATH=''
@@ -14,10 +16,12 @@ def run_cmd(cmd):
     print(cmd)
     args = shlex.split(cmd)
     is_shell = platform.system() == 'Windows'
-    subprocess.call(args, cwd=TENSORFLOW_PATH, shell=is_shell)
+    ret = subprocess.call(args, cwd=TENSORFLOW_PATH, shell=is_shell)
+    if ret != 0:
+        sys.exit(ret)
 
 def copy(from_tf, to_unity):
-    subprocess.call(['cp', '-vf', f'{TENSORFLOW_PATH}/{from_tf}', f'{PLUGIN_PATH}/{to_unity}'])
+    shutil.copy(f'{TENSORFLOW_PATH}/{from_tf}', f'{PLUGIN_PATH}/{to_unity}')
 
 def unzip(from_tf, to_unity):
     subprocess.call(['unzip', '-o', f'{TENSORFLOW_PATH}/{from_tf}', '-d' f'{PLUGIN_PATH}/{to_unity}'])

--- a/build_tflite.py
+++ b/build_tflite.py
@@ -89,14 +89,14 @@ def build_linux(enable_xnnpack = True):
 
 def build_ios():
     # Main
-    run_cmd('bazel build -c opt --config=ios_fat --cxxopt=--std=c++17 //tensorflow/lite/ios:TensorFlowLiteC_framework')
+    run_cmd('bazel build -c opt --config=ios_arm64 --cxxopt=--std=c++17 //tensorflow/lite/ios:TensorFlowLiteC_framework')
     unzip('bazel-bin/tensorflow/lite/ios/TensorFlowLiteC_framework.zip', 'iOS')
     # Metal Delegate
-    run_cmd('bazel build -c opt --config=ios_fat --cxxopt=--std=c++17 //tensorflow/lite/ios:TensorFlowLiteCMetal_framework')
+    run_cmd('bazel build -c opt --config=ios_arm64 --cxxopt=--std=c++17 //tensorflow/lite/ios:TensorFlowLiteCMetal_framework')
     unzip('bazel-bin/tensorflow/lite/ios/TensorFlowLiteCMetal_framework.zip', 'iOS')
     # CoreML Delegate
-    # run_cmd('bazel build -c opt --config=ios_fat --cxxopt=--std=c++17 //tensorflow/lite/ios:TensorFlowLiteCCoreML_framework')
-    # unzip('bazel-bin/tensorflow/lite/ios/TensorFlowLiteCCoreML_framework.zip', 'iOS')
+    run_cmd('bazel build -c opt --config=ios_arm64 --cxxopt=--std=c++17 //tensorflow/lite/ios:TensorFlowLiteCCoreML_framework')
+    unzip('bazel-bin/tensorflow/lite/ios/TensorFlowLiteCCoreML_framework.zip', 'iOS')
     # SelectOps Delegate
     # run_cmd('bazel build -c opt --config=ios --ios_multi_cpus=armv7,arm64,x86_64 //tensorflow/lite/ios:TensorFlowLiteSelectTfOps_framework')
     # unzip('bazel-bin/tensorflow/lite/ios/TensorFlowLiteSelectTfOps_framework.zip', 'iOS')

--- a/build_tflite.py
+++ b/build_tflite.py
@@ -89,13 +89,13 @@ def build_linux(enable_xnnpack = True):
 
 def build_ios():
     # Main
-    run_cmd('bazel build -c opt --config=ios_fat //tensorflow/lite/ios:TensorFlowLiteC_framework')
+    run_cmd('bazel build -c opt --config=ios_fat --cxxopt=--std=c++17 //tensorflow/lite/ios:TensorFlowLiteC_framework')
     unzip('bazel-bin/tensorflow/lite/ios/TensorFlowLiteC_framework.zip', 'iOS')
     # Metal Delegate
-    run_cmd('bazel build -c opt --config=ios_fat //tensorflow/lite/ios:TensorFlowLiteCMetal_framework')
+    run_cmd('bazel build -c opt --config=ios_fat --cxxopt=--std=c++17 //tensorflow/lite/ios:TensorFlowLiteCMetal_framework')
     unzip('bazel-bin/tensorflow/lite/ios/TensorFlowLiteCMetal_framework.zip', 'iOS')
     # CoreML Delegate
-    # run_cmd('bazel build -c opt --config=ios_fat //tensorflow/lite/ios:TensorFlowLiteCCoreML_framework')
+    # run_cmd('bazel build -c opt --config=ios_fat --cxxopt=--std=c++17 //tensorflow/lite/ios:TensorFlowLiteCCoreML_framework')
     # unzip('bazel-bin/tensorflow/lite/ios/TensorFlowLiteCCoreML_framework.zip', 'iOS')
     # SelectOps Delegate
     # run_cmd('bazel build -c opt --config=ios --ios_multi_cpus=armv7,arm64,x86_64 //tensorflow/lite/ios:TensorFlowLiteSelectTfOps_framework')


### PR DESCRIPTION
Hi, I'm ready to send PR to build the native plugins by CircleCI.
As the following result showed, CircleCI can build the all (macOS, Windows, Linux, iOS, Android) TFLite 2.10.0 native plugins successfully on `free` account.

https://app.circleci.com/pipelines/github/stakemura/tf-lite-unity-sample/53/workflows/9995ca29-237f-4276-ad68-2dacd6152387

As for the gpu-api-delegate, please comment out the following patch.

```
# For gpu-api-delegate branch
# sed -i -e 's/libtensorflowlite_gpu_delegate.so/libtensorflowlite_gpu_api_delegate.so/' ../tensorflow/tensorflow/lite/delegates/gpu/BUILD 
# sed -i -e 's/\":delegate\"/\"\/\/tensorflow\/lite\/delegates\/gpu\/cl:gpu_api_delegate\"/' ../tensorflow/tensorflow/lite/delegates/gpu/BUILD
```

Also I need some modifications about `build_tflite.py` to support continuous builds.
For example, I made it possible to return the error code when bazel failed to build. 

```
    ret = subprocess.call(args, cwd=TENSORFLOW_PATH, shell=is_shell)
    if ret != 0:
        sys.exit(ret)
```

I would appreciate it if you could consider the merge.