### PR TITLE
Add NN Api Delegate

### DIFF
--- a/Assets/Samples/MNIST/MnistSample.cs
+++ b/Assets/Samples/MNIST/MnistSample.cs
@@ -25,7 +25,6 @@ public class MnistSample : MonoBehaviour
         var options = new InterpreterOptions()
         {
             threads = 2,
-            useNNAPI = false,
         };
         interpreter = new Interpreter(FileUtil.LoadFile(fileName), options);
         interpreter.ResizeInputTensor(0, new int[] { 1, 28, 28, 1 });

--- a/Assets/Samples/SSD/SSD.cs
+++ b/Assets/Samples/SSD/SSD.cs
@@ -43,6 +43,12 @@ namespace TensorFlowLite
             resizeOptions.aspectMode = options.aspectMode;
         }
 
+        public SSD(Options options, InterpreterOptions interpreterOptions)
+            : base(options.modelPath, interpreterOptions)
+        {
+            resizeOptions.aspectMode = options.aspectMode;
+        }
+
         public override void Invoke(Texture inputTex)
         {
             ToTensor(inputTex, inputTensor);

--- a/Assets/Samples/SSD/SSD.unity
+++ b/Assets/Samples/SSD/SSD.unity
@@ -658,7 +658,7 @@ MonoBehaviour:
   options:
     modelPath: coco_ssd_mobilenet_quant.tflite
     aspectMode: 1
-    accelerator: 1
+    accelerator: 2
   frameContainer: {fileID: 2074584280}
   framePrefab: {fileID: 5133934790876113832, guid: 717c89ea2a05f4537b007f12d6357590,
     type: 3}

--- a/Assets/Samples/SSD/SSD.unity
+++ b/Assets/Samples/SSD/SSD.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.3708625, g: 0.37838694, b: 0.35726872, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311915, g: 0.3807396, b: 0.35872662, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -658,7 +658,7 @@ MonoBehaviour:
   options:
     modelPath: coco_ssd_mobilenet_quant.tflite
     aspectMode: 1
-    accelerator: 2
+    accelerator: 1
   frameContainer: {fileID: 2074584280}
   framePrefab: {fileID: 5133934790876113832, guid: 717c89ea2a05f4537b007f12d6357590,
     type: 3}

--- a/Assets/Samples/SSD/SsdSample.cs
+++ b/Assets/Samples/SSD/SsdSample.cs
@@ -26,7 +26,25 @@ public class SsdSample : MonoBehaviour
 
     private void Start()
     {
-        ssd = new SSD(options);
+#if UNITY_ANDROID && !UNITY_EDITOR
+        // This is an example usage of the NNAPI delegate.
+        if (options.accelerator == SSD.Accelerator.NNAPI && !Application.isEditor)
+        {
+            string cacheDir = Application.persistentDataPath;
+            string modelToken = "ssd-token";
+            var interpreterOptions = new InterpreterOptions();
+            var nnapiOptions = NNAPIDelegate.DefaultOptions;
+            nnapiOptions.AllowFp16 = true;
+            nnapiOptions.CacheDir = cacheDir;
+            nnapiOptions.ModelToken = modelToken;
+            interpreterOptions.AddDelegate(new NNAPIDelegate(nnapiOptions));
+            ssd = new SSD(options, interpreterOptions);
+        }
+        else
+#endif // UNITY_ANDROID && !UNITY_EDITOR
+        {
+            ssd = new SSD(options);
+        }
 
         // Init frames
         frames = new Text[10];

--- a/Assets/Samples/VideoClassification/VideoClassification.cs
+++ b/Assets/Samples/VideoClassification/VideoClassification.cs
@@ -63,7 +63,10 @@ namespace TensorFlowLite
                 case Accelerator.NNAPI:
                     if (Application.platform == RuntimePlatform.Android)
                     {
-                        interpreterOptions.useNNAPI = true;
+#if UNITY_ANDROID && !UNITY_EDITOR
+                        // Create NNAPI delegate with default options
+                        interpreterOptions.AddDelegate(new NNAPIDelegate());
+#endif // UNITY_ANDROID && !UNITY_EDITOR
                     }
                     else
                     {

--- a/Packages/com.github.asus4.tflite.common/Runtime/BaseImagePredictor.cs
+++ b/Packages/com.github.asus4.tflite.common/Runtime/BaseImagePredictor.cs
@@ -103,7 +103,6 @@ namespace TensorFlowLite
         {
             var options = new InterpreterOptions();
 
-            // Debug.Log($"Accelerator: {accelerator}");
             switch (accelerator)
             {
                 case Accelerator.NONE:
@@ -112,7 +111,10 @@ namespace TensorFlowLite
                 case Accelerator.NNAPI:
                     if (Application.platform == RuntimePlatform.Android)
                     {
-                        options.useNNAPI = true;
+#if UNITY_ANDROID && !UNITY_EDITOR
+                        // Create NNAPI delegate with default options
+                        options.AddDelegate(new NNAPIDelegate());
+#endif // UNITY_ANDROID && !UNITY_EDITOR
                     }
                     else
                     {

--- a/Packages/com.github.asus4.tflite/Runtime/Delegates/NNAPIDelegate.cs
+++ b/Packages/com.github.asus4.tflite/Runtime/Delegates/NNAPIDelegate.cs
@@ -1,0 +1,140 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// #if UNITY_ANDROID && !UNITY_EDITOR
+#if UNITY_ANDROID // to test
+
+using System;
+using System.Runtime.InteropServices;
+using TfLiteDelegate = System.IntPtr;
+
+namespace TensorFlowLite
+{
+    public sealed class NNAPIDelegate : IDelegate
+    {
+        /// <summary>
+        /// Preferred Power/perf trade-off. For more details please see
+        /// ANeuralNetworksCompilation_setPreference documentation in :
+        /// https://developer.android.com/ndk/reference/group/neural-networks.html
+        /// </summary>
+        [Flags]
+        public enum ExecutionPreference : int
+        {
+            Undefined = -1,
+            LowPower = 0,
+            FastSingleAnswer = 1,
+            SustainedSpeed = 2,
+        };
+
+        /// <summary>
+        /// The Mirror of TfLiteNnapiDelegateOptions
+        /// Use TfLiteNnapiDelegateOptionsDefault() for Default options.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Options
+        {
+            // Preferred Power/perf trade-off. Default to kUndefined.
+            public ExecutionPreference executionPreference;
+
+            // Selected NNAPI accelerator with nul-terminated name.
+            // Default to nullptr, which implies the NNAPI default behavior: NNAPI
+            // runtime is allowed to use all available accelerators. If the selected
+            // accelerator cannot be found, NNAPI will not be used.
+            // It is the caller's responsibility to ensure the string is valid for the
+            // duration of the Options object lifetime.
+            public IntPtr acceleratorName; // char*
+
+            // The nul-terminated cache dir for NNAPI model.
+            // Default to nullptr, which implies the NNAPI will not try caching the
+            // compilation.
+            public IntPtr cacheDir; // char*
+
+            // The unique nul-terminated token string for NNAPI model.
+            // Default to nullptr, which implies the NNAPI will not try caching the
+            // compilation. It is the caller's responsibility to ensure there is no
+            // clash of the tokens.
+            // NOTE: when using compilation caching, it is not recommended to use the
+            // same delegate instance for multiple models.
+            public IntPtr modelToken; // char*
+
+            // Whether to disallow NNAPI CPU usage. Default to 1 (true). Only effective on
+            // Android 10 and above. The NNAPI CPU typically performs less well than
+            // built-in TfLite kernels, but allowing CPU allows partial acceleration of
+            // models. If this is set to true, NNAPI is only used if the whole model is
+            // accelerated.
+            public int disallowNnapiCpu;
+
+            // Whether to allow fp32 computation to be run in fp16. Default to 0 (false).
+            public int allowFp16;
+
+            // Specifies the max number of partitions to delegate. A value <= 0 means
+            // no limit. Default to 3.
+            // If the delegation of the full set of supported nodes would generate a
+            // number of partition greater than this parameter, only
+            // <max_number_delegated_partitions> of them will be actually accelerated.
+            // The selection is currently done sorting partitions in decreasing order
+            // of number of nodes and selecting them until the limit is reached.
+            public int maxNumberDelegatedPartitions;
+
+            // The pointer to NNAPI support lib implementation. Default to nullptr.
+            // If specified, NNAPI delegate will use the support lib instead of NNAPI in
+            // Android OS.
+            public IntPtr nnapi_support_library_handle; // void*
+        }
+
+        public TfLiteDelegate Delegate { get; private set; }
+
+        public static Options DefaultOptions => TfLiteNnapiDelegateOptionsDefault();
+
+        public NNAPIDelegate() : this(DefaultOptions)
+        {
+        }
+
+        public NNAPIDelegate(Options options)
+        {
+            UnityEngine.Debug.Log("NNAPIDelegate Created");
+            Delegate = TfLiteNnapiDelegateCreate(ref options);
+        }
+
+        public void Dispose()
+        {
+            if (Delegate != IntPtr.Zero)
+            {
+                TfLiteNnapiDelegateDelete(Delegate);
+                Delegate = IntPtr.Zero;
+            }
+        }
+
+        #region Externs
+        internal const string TensorFlowLibrary = Interpreter.TensorFlowLibrary;
+
+        // Returns a delegate that uses NNAPI for ops execution.
+        // Must outlive the interpreter.
+        [DllImport(TensorFlowLibrary)]
+        private static extern unsafe TfLiteDelegate TfLiteNnapiDelegateCreate(ref Options options);
+
+        // Returns TfLiteNnapiDelegateOptions populated with default values.
+        [DllImport(TensorFlowLibrary)]
+        private static extern unsafe Options TfLiteNnapiDelegateOptionsDefault();
+
+        // Does any needed cleanup and deletes 'delegate'.
+        [DllImport(TensorFlowLibrary)]
+        private static extern unsafe void TfLiteNnapiDelegateDelete(TfLiteDelegate delegateHandle);
+
+        #endregion // Externs
+    }
+}
+
+#endif // UNITY_ANDROID && !UNITY_EDITOR

--- a/Packages/com.github.asus4.tflite/Runtime/Delegates/NNAPIDelegate.cs
+++ b/Packages/com.github.asus4.tflite/Runtime/Delegates/NNAPIDelegate.cs
@@ -13,8 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-// #if UNITY_ANDROID && !UNITY_EDITOR
-#if UNITY_ANDROID // to test
+#if UNITY_ANDROID && !UNITY_EDITOR
 
 using System;
 using System.Runtime.InteropServices;
@@ -92,6 +91,31 @@ namespace TensorFlowLite
             // If specified, NNAPI delegate will use the support lib instead of NNAPI in
             // Android OS.
             public IntPtr nnapi_support_library_handle; // void*
+
+
+            public string CacheDir
+            {
+                get => Marshal.PtrToStringAuto(cacheDir);
+                set
+                {
+                    cacheDir = Marshal.StringToHGlobalAuto(value);
+                }
+            }
+
+            public string ModelToken
+            {
+                get => Marshal.PtrToStringAuto(modelToken);
+                set
+                {
+                    modelToken = Marshal.StringToHGlobalAuto(value);
+                }
+            }
+
+            public bool AllowFp16
+            {
+                get => allowFp16 > 0;
+                set => allowFp16 = value ? 1 : 0;
+            }
         }
 
         public TfLiteDelegate Delegate { get; private set; }

--- a/Packages/com.github.asus4.tflite/Runtime/Delegates/NNAPIDelegate.cs.meta
+++ b/Packages/com.github.asus4.tflite/Runtime/Delegates/NNAPIDelegate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e5584db5b4984d9b9d9744ef25d5da1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.asus4.tflite/Runtime/InterpreterOptions.cs
+++ b/Packages/com.github.asus4.tflite/Runtime/InterpreterOptions.cs
@@ -43,6 +43,7 @@ namespace TensorFlowLite
         }
 
         private bool _useNNAPI;
+        [Obsolete("useNNAPI option is deprecated, use NNAPIDelegate instead.")]
         public bool useNNAPI
         {
             get => _useNNAPI;
@@ -50,7 +51,8 @@ namespace TensorFlowLite
             {
                 _useNNAPI = value;
 #if UNITY_ANDROID && !UNITY_EDITOR
-                InterpreterExperimental.TfLiteInterpreterOptionsSetUseNNAPI(nativePtr, value);
+                // Create NNAPI delegate with default options
+                AddDelegate(new NNAPIDelegate());
 #endif // UNITY_ANDROID && !UNITY_EDITOR
             }
         }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -15,7 +15,7 @@
     "com.unity.ext.nunit": "1.0.6",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.mathematics": "1.2.6",
-    "com.unity.render-pipelines.universal": "10.9.0",
+    "com.unity.render-pipelines.universal": "10.10.0",
     "com.unity.test-framework": "1.1.33",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -15,7 +15,7 @@
     "com.unity.ext.nunit": "1.0.6",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.mathematics": "1.2.6",
-    "com.unity.render-pipelines.universal": "10.10.0",
+    "com.unity.render-pipelines.universal": "10.10.1",
     "com.unity.test-framework": "1.1.33",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -65,7 +65,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
-      "version": "10.9.0",
+      "version": "10.10.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -76,13 +76,13 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.universal": {
-      "version": "10.9.0",
+      "version": "10.10.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.unity.mathematics": "1.1.0",
-        "com.unity.render-pipelines.core": "10.9.0",
-        "com.unity.shadergraph": "10.9.0"
+        "com.unity.render-pipelines.core": "10.10.0",
+        "com.unity.shadergraph": "10.10.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -94,11 +94,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.shadergraph": {
-      "version": "10.9.0",
+      "version": "10.10.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.render-pipelines.core": "10.9.0",
+        "com.unity.render-pipelines.core": "10.10.0",
         "com.unity.searcher": "4.3.2"
       },
       "url": "https://packages.unity.com"

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -65,7 +65,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
-      "version": "10.10.0",
+      "version": "10.10.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -76,13 +76,13 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.universal": {
-      "version": "10.10.0",
+      "version": "10.10.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.unity.mathematics": "1.1.0",
-        "com.unity.render-pipelines.core": "10.10.0",
-        "com.unity.shadergraph": "10.10.0"
+        "com.unity.render-pipelines.core": "10.10.1",
+        "com.unity.shadergraph": "10.10.1"
       },
       "url": "https://packages.unity.com"
     },
@@ -94,11 +94,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.shadergraph": {
-      "version": "10.10.0",
+      "version": "10.10.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.render-pipelines.core": "10.10.0",
+        "com.unity.render-pipelines.core": "10.10.1",
         "com.unity.searcher": "4.3.2"
       },
       "url": "https://packages.unity.com"

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -24,25 +24,28 @@ MonoBehaviour:
     m_Scopes: []
     m_IsDefault: 1
     m_Capabilities: 7
-  - m_Id: scoped:npm
+    m_ConfigSource: 0
+  - m_Id: scoped:project:npm
     m_Name: npm
     m_Url: https://registry.npmjs.com
     m_Scopes:
     - com.github.asus4
     m_IsDefault: 0
     m_Capabilities: 0
+    m_ConfigSource: 4
   m_UserSelectedRegistryName: 
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
     m_ErrorMessage: 
     m_Original:
-      m_Id: scoped:npm
+      m_Id: scoped:project:npm
       m_Name: npm
       m_Url: https://registry.npmjs.com
       m_Scopes:
       - com.github.asus4
       m_IsDefault: 0
       m_Capabilities: 0
+      m_ConfigSource: 4
     m_Modified: 0
     m_Name: npm
     m_Url: https://registry.npmjs.com

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.41f1
-m_EditorVersionWithRevision: 2020.3.41f1 (7c19dc9acfda)
+m_EditorVersion: 2020.3.43f1
+m_EditorVersionWithRevision: 2020.3.43f1 (75bff06b76bf)

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.36f1
-m_EditorVersionWithRevision: 2020.3.36f1 (71f96b79b9f0)
+m_EditorVersion: 2020.3.41f1
+m_EditorVersionWithRevision: 2020.3.41f1 (7c19dc9acfda)

--- a/ProjectSettings/UnityConnectSettings.asset
+++ b/ProjectSettings/UnityConnectSettings.asset
@@ -9,6 +9,7 @@ UnityConnectSettings:
   m_EventOldUrl: https://api.uca.cloud.unity3d.com/v1/events
   m_EventUrl: https://cdp.cloud.unity3d.com/v1/events
   m_ConfigUrl: https://config.uca.cloud.unity3d.com
+  m_DashboardUrl: https://dashboard.unity3d.com
   m_TestInitMode: 0
   CrashReportingSettings:
     m_EventUrl: https://perf-events.cloud.unity3d.com
@@ -22,6 +23,7 @@ UnityConnectSettings:
     m_Enabled: 0
     m_TestMode: 0
     m_InitializeOnStartup: 1
+    m_PackageRequiringCoreStatsPresent: 0
   UnityAdsSettings:
     m_Enabled: 0
     m_InitializeOnStartup: 1


### PR DESCRIPTION
[Android Neural Networks API](https://developer.android.com/ndk/guides/neuralnetwork) has been supported as an `useNNAPI` option in the `InterpreterOptions.cs`. But there was no way to configure options in the NNAPI.

This PR allows configuring all options supported in the [original TFLite CAPI](https://github.com/tensorflow/tensorflow/blob/359c3cdfc5fabac82b3c70b3b6de2b0a8c16874f/tensorflow/lite/delegates/nnapi/nnapi_delegate_c_api.h).

Please take a look at SsdSample.cs for an example of usage.

