### PR TITLE
Upgrade TensorFlow Lite libraries to v2.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,8 +130,8 @@ jobs:
       image: android:202102-01
     environment:
       ANDROID_SDK_API_LEVEL: 23
-      ANDROID_NDK_API_LEVEL: 21
-      ANDROID_BUILD_TOOLS_VERSION: 30.0.3
+      ANDROID_NDK_API_LEVEL: 26
+      ANDROID_BUILD_TOOLS_VERSION: 31.0.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,12 @@ parameters:
     default: "git@github.com:tensorflow/tensorflow.git"
   tf-branch:
     type: string
-    default: "v2.12.0"
+    default: "v2.13.0"
 
 jobs:
   build-mac:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     steps:
       - checkout
       - run:
@@ -98,7 +98,7 @@ jobs:
           path: Linux.tar
   build-ios:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     steps:
       - checkout
       - run:

--- a/Packages/com.github.asus4.tflite/Runtime/BuiltinOps.cs
+++ b/Packages/com.github.asus4.tflite/Runtime/BuiltinOps.cs
@@ -179,5 +179,8 @@ namespace TensorFlowLite
         Atan2 = 156,
         UnsortedSegmentMin = 157,
         Sign = 158,
+        Bitcast = 159,
+        BitwiseXor = 160,
+        RightShift = 161,
     }
 }

--- a/Packages/com.github.asus4.tflite/Runtime/Delegates/XNNPackDelegate.cs
+++ b/Packages/com.github.asus4.tflite/Runtime/Delegates/XNNPackDelegate.cs
@@ -32,6 +32,9 @@ namespace TensorFlowLite
             QU8 = 0x00000002,
             // Force FP16 inference for FP32 operators.
             FORCE_FP16 = 0x00000004,
+            // Enable XNNPACK acceleration for FULLY_CONNECTED operator with dynamic
+            //weights.
+            DYNAMIC_FULLY_CONNECTED = 0x00000008,
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -46,7 +49,7 @@ namespace TensorFlowLite
             public TfLiteXNNPackDelegateWeightsCache weightsCache;
             // Whether READ_VARIABLE, ASSIGN_VARIABLE, and VARIABLE_HANDLE operations
             // should be handled by XNNPACK.
-            bool handleVariableOps;
+            public bool handleVariableOps;
         }
 
         public TfLiteDelegate Delegate { get; private set; }

--- a/build_tflite.py
+++ b/build_tflite.py
@@ -107,9 +107,8 @@ def build_ios():
     # run_cmd('bazel build -c opt --config=ios --ios_multi_cpus=armv7,arm64,x86_64 //tensorflow/lite/ios:TensorFlowLiteSelectTfOps_framework')
     # unzip('bazel-bin/tensorflow/lite/ios/TensorFlowLiteSelectTfOps_framework.zip', 'iOS')
 
-def build_android(enable_xnnpack = True):
+def build_android():
     # Main
-    option_xnnpack = 'true' if enable_xnnpack else 'false'
     run_cmd(f'bazel build -c opt --fat_apk_cpu=arm64-v8a,armeabi-v7a,x86_64 //tensorflow/lite/java:tensorflow-lite')
     copy('bazel-bin/tensorflow/lite/java/tensorflow-lite.aar', 'Android')
 
@@ -173,4 +172,4 @@ if __name__ == '__main__':
     if args.android:
         # Need to set Android build option in ./configure
         print('Build Android')
-        build_android(args.xnnpack)
+        build_android()

--- a/build_tflite.py
+++ b/build_tflite.py
@@ -34,6 +34,10 @@ def patch(file_path, target_str, patched_str):
         file.write(source)
 
 def build_mac(enable_xnnpack = True):
+    # Workaround for macOS build error
+    # https://github.com/tensorflow/tensorflow/pull/60771
+    run_cmd(f'git cherry-pick 4869e557d603b211ca7d0b4640ee9aac08b48565 --no-commit')
+    
     # Main
     option_xnnpack = 'true' if enable_xnnpack else 'false'
     run_cmd(f'bazel build --config=macos --cpu=darwin -c opt --define tflite_with_xnnpack={option_xnnpack} tensorflow/lite/c:tensorflowlite_c')
@@ -57,6 +61,8 @@ def build_mac(enable_xnnpack = True):
     run_cmd(f'lipo -create -output {PLUGIN_PATH}/macOS/libtensorflowlite_metal_delegate.dylib ' + ' '.join(metal_delegate_pathes))
     # Restore patch
     patch(cpuinfo_file, patched, original)
+    # Restore workaround
+    run_cmd('git reset --hard')
 
 def build_windows(enable_xnnpack = True):
     # Main


### PR DESCRIPTION
- [x] macOS
- [x] iOS
- [x] Android
- [ ] Linux
- [ ] Windows  
