### PR TITLE
WebCamInput Development

### DIFF
--- a/Packages/com.github.asus4.tflite.common/Editor/WebCamNameDrawer.cs
+++ b/Packages/com.github.asus4.tflite.common/Editor/WebCamNameDrawer.cs
@@ -28,10 +28,7 @@ namespace TensorFlowLite
                 displayNames = WebCamTexture.devices.Select(device => device.name).ToArray();
             }
 
-            if (selectedIndex < 0)
-            {
-                selectedIndex = FindSelectedIndex(displayNames, property.stringValue);
-            }
+            selectedIndex = FindSelectedIndex(displayNames, property.stringValue);
 
             EditorGUI.BeginProperty(position, label, property);
 

--- a/Packages/com.github.asus4.tflite.common/Runtime/WebCamInput.cs
+++ b/Packages/com.github.asus4.tflite.common/Runtime/WebCamInput.cs
@@ -24,6 +24,9 @@ namespace TensorFlowLite
         private WebCamDevice[] devices;
         private int deviceIndex;
 
+        public Vector2Int RequestSize { get => requestSize; set => requestSize = value; }
+        public int RequestFps { get => requestFps; set => requestFps = value; }
+
         private void Start()
         {
             resizer = new TextureResizer();

--- a/Packages/com.github.asus4.tflite.common/Runtime/WebCamInput.cs
+++ b/Packages/com.github.asus4.tflite.common/Runtime/WebCamInput.cs
@@ -26,12 +26,13 @@ namespace TensorFlowLite
 
         public Vector2Int RequestSize { get => requestSize; set => requestSize = value; }
         public int RequestFps { get => requestFps; set => requestFps = value; }
+        public string RequestCameraByDeviceName { get => editorCameraName; set => editorCameraName = value; }
 
-        private void Start()
+        private void OnEnable()
         {
             resizer = new TextureResizer();
             devices = WebCamTexture.devices;
-            string cameraName = Application.isEditor
+            string cameraName = Application.isEditor || !string.IsNullOrEmpty(editorCameraName)
                 ? editorCameraName
                 : WebCamUtil.FindName(preferKind, isFrontFacing);
 
@@ -48,6 +49,11 @@ namespace TensorFlowLite
             StartCamera(device);
         }
 
+        private void OnDisable()
+        {
+            PauseCamera();
+        }
+
         private void OnDestroy()
         {
             StopCamera();
@@ -58,7 +64,7 @@ namespace TensorFlowLite
         {
             if (!webCamTexture.didUpdateThisFrame) return;
 
-            var tex = NormalizeWebcam(webCamTexture, Screen.width, Screen.height, isFrontFacing);
+            var tex = NormalizeWebcam(webCamTexture, requestSize.x, requestSize.y, isFrontFacing);
             OnTextureUpdate.Invoke(tex);
         }
 
@@ -77,7 +83,14 @@ namespace TensorFlowLite
             webCamTexture = new WebCamTexture(device.name, requestSize.x, requestSize.y, requestFps);
             webCamTexture.Play();
         }
-
+        private void PauseCamera()
+        {
+            if (webCamTexture == null)
+            {
+                return;
+            }
+            webCamTexture.Stop();
+        }
         private void StopCamera()
         {
             if (webCamTexture == null)


### PR DESCRIPTION
Added properties to support setting camera configuration externally via script

Added support for auto detecting multiple cameras when using multiple WebCamInput objects in the scene and they're all set to open the same camera, in this case it will auto detect the next available camera

Allowed WebCamName property drawer to receive a value set from script and update the inspector accordingly

Paused camera when WebCamInput object is disabled