### PR TITLE
Adjustment to SSD Bounding Box Size Calculation to Account for Texture Aspect Ratio

### DIFF
--- a/Assets/Samples/SSD/SsdSample.cs
+++ b/Assets/Samples/SSD/SsdSample.cs
@@ -1,4 +1,4 @@
-﻿using TensorFlowLite;
+﻿�sing TensorFlowLite;
 using UnityEngine;
 using UnityEngine.UI;
 using TextureSource;
@@ -114,3 +114,4 @@ public class SsdSample : MonoBehaviour
     }
 
 }
+

--- a/Assets/Samples/SSD/SsdSample.cs
+++ b/Assets/Samples/SSD/SsdSample.cs
@@ -1,4 +1,4 @@
-ï»¿õsing TensorFlowLite;
+using TensorFlowLite;
 using UnityEngine;
 using UnityEngine.UI;
 using TextureSource;
@@ -77,12 +77,23 @@ public class SsdSample : MonoBehaviour
     private void Invoke(Texture texture)
     {
         ssd.Run(texture);
-
+        
         SSD.Result[] results = ssd.GetResults();
         Vector2 size = (frameContainer.transform as RectTransform).rect.size;
+
+        Vector2 ratio;
+        if (texture.width >= texture.height)
+        {
+            ratio = new Vector2(1.0f, (float)texture.height / (float)texture.width);
+        }
+        else
+        {
+            ratio = new Vector2((float)texture.width / (float)texture.height, 1.0f);
+        }
+
         for (int i = 0; i < 10; i++)
         {
-            SetFrame(frames[i], results[i], size);
+            SetFrame(frames[i], results[i], size * ratio);
         }
     }
 


### PR DESCRIPTION
Hello,

I have noticed that the current implementation does not fully accommodate textures where the width is greater than the height, leading to inaccurately scaled bounding boxes for wider textures. This PR proposes a solution to dynamically adjust the scaling based on the texture's aspect ratio, ensuring that bounding boxes are correctly scaled regardless of whether the texture is wider or taller.

This adjustment ensures that the bounding boxes are always scaled appropriately, improving the accuracy of the visual representation of detected objects.