### PR TITLE
Remove microphone buffer class from WebGL build

### DIFF
--- a/Packages/com.github.asus4.tflite.common/Runtime/MicrophoneBuffer.cs
+++ b/Packages/com.github.asus4.tflite.common/Runtime/MicrophoneBuffer.cs
@@ -1,3 +1,5 @@
+#if !UNITY_WEBGL // Microphone API is not supported in WebGL
+
 using System;
 using System.Buffers;
 using System.Collections;
@@ -162,3 +164,4 @@ namespace TensorFlowLite
 #endif
     }
 }
+#endif // !UNITY_WEBGL


### PR DESCRIPTION
Disable MicrophoneBuffer class on WebGL build to avoid compile error