### PR TITLE
Fix signature runner crash

### DIFF
--- a/Assets/Samples/VideoClassification/VideoClassification.cs
+++ b/Assets/Samples/VideoClassification/VideoClassification.cs
@@ -57,6 +57,7 @@ namespace TensorFlowLite
             try
             {
                 runner = new SignatureRunner(SIGNATURE_KEY, FileUtil.LoadFile(options.modelPath), interpreterOptions);
+                runner.AllocateSignatureTensors();
             }
             catch (Exception e)
             {

--- a/Packages/com.github.asus4.tflite.common/Runtime/InterpreterExtension.cs
+++ b/Packages/com.github.asus4.tflite.common/Runtime/InterpreterExtension.cs
@@ -54,7 +54,7 @@ namespace TensorFlowLite
             }
             sb.AppendLine();
 
-            int signatureInputCount = runner.GetSignatureInputCount();
+            int signatureInputCount = (int)runner.GetSignatureInputCount();
             for (int i = 0; i < signatureInputCount; i++)
             {
                 string name = runner.GetSignatureInputName(i);
@@ -62,7 +62,7 @@ namespace TensorFlowLite
             }
             sb.AppendLine();
 
-            int signatureOutputCount = runner.GetSignatureOutputCount();
+            int signatureOutputCount = (int)runner.GetSignatureOutputCount();
             for (int i = 0; i < signatureOutputCount; i++)
             {
                 string name = runner.GetSignatureOutputName(i);

--- a/Packages/com.github.asus4.tflite/Runtime/SignatureRunner.cs
+++ b/Packages/com.github.asus4.tflite/Runtime/SignatureRunner.cs
@@ -73,7 +73,7 @@ namespace TensorFlowLite
             return ToString(TfLiteInterpreterGetSignatureKey(InterpreterPointer, index));
         }
 
-        public int GetSignatureInputCount()
+        public ulong GetSignatureInputCount()
         {
             return TfLiteSignatureRunnerGetInputCount(runner);
         }
@@ -138,7 +138,7 @@ namespace TensorFlowLite
             ThrowIfError(TfLiteSignatureRunnerInvoke(runner));
         }
 
-        public int GetSignatureOutputCount()
+        public ulong GetSignatureOutputCount()
         {
             return TfLiteSignatureRunnerGetOutputCount(runner);
         }
@@ -199,7 +199,7 @@ namespace TensorFlowLite
 
         private Dictionary<string, int> CreateMap(bool isInput)
         {
-            int signatureCount = isInput ? GetSignatureInputCount() : GetSignatureOutputCount();
+            int signatureCount = (int)(isInput ? GetSignatureInputCount() : GetSignatureOutputCount());
             int tensorCount = isInput ? GetInputTensorCount() : GetOutputTensorCount();
             Assert.AreEqual(signatureCount, tensorCount);
 
@@ -270,7 +270,7 @@ namespace TensorFlowLite
         private static extern TfLiteSignatureRunner TfLiteInterpreterGetSignatureRunner(TfLiteInterpreter interpreter, string signature_name);
 
         [DllImport(TensorFlowLibrary)]
-        private static extern int TfLiteSignatureRunnerGetInputCount(TfLiteSignatureRunner signature_runner);
+        private static extern ulong TfLiteSignatureRunnerGetInputCount(TfLiteSignatureRunner signature_runner);
 
         [DllImport(TensorFlowLibrary)]
         private static extern IntPtr TfLiteSignatureRunnerGetInputName(TfLiteSignatureRunner signature_runner, int input_index);
@@ -290,7 +290,7 @@ namespace TensorFlowLite
         private static extern Status TfLiteSignatureRunnerInvoke(TfLiteSignatureRunner signature_runner);
 
         [DllImport(TensorFlowLibrary)]
-        private static extern int TfLiteSignatureRunnerGetOutputCount(TfLiteSignatureRunner signature_runner);
+        private static extern ulong TfLiteSignatureRunnerGetOutputCount(TfLiteSignatureRunner signature_runner);
 
         [DllImport(TensorFlowLibrary)]
         private static extern IntPtr TfLiteSignatureRunnerGetOutputName(TfLiteSignatureRunner signature_runner, int output_index);


### PR DESCRIPTION

## VideoClassification
- Fix crashing by allocating tensors during the initialization step.
