### PR TITLE
Upgrade Unity to LTS 2022.3.62f1 to support 16kb alignment in Burst lib 

### DIFF
--- a/Packages/com.github.asus4.tflite/Plugins/Android/arm64-v8a/libtensorflowlite_gpu_gl.so.meta
+++ b/Packages/com.github.asus4.tflite/Plugins/Android/arm64-v8a/libtensorflowlite_gpu_gl.so.meta
@@ -16,7 +16,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        Exclude Android: 0
+        Exclude Android: 1
         Exclude Editor: 1
         Exclude Linux64: 1
         Exclude OSXUniversal: 1
@@ -26,7 +26,7 @@ PluginImporter:
   - first:
       Android: Android
     second:
-      enabled: 1
+      enabled: 0
       settings:
         AndroidSharedLibraryType: Executable
         CPU: ARM64

--- a/Packages/com.github.asus4.tflite/Plugins/Android/arm64-v8a/libtensorflowlite_gpu_gl.so.meta
+++ b/Packages/com.github.asus4.tflite/Plugins/Android/arm64-v8a/libtensorflowlite_gpu_gl.so.meta
@@ -6,7 +6,7 @@ PluginImporter:
   iconMap: {}
   executionOrder: {}
   defineConstraints: []
-  isPreloaded: 1
+  isPreloaded: 0
   isOverridable: 1
   isExplicitlyReferenced: 0
   validateReferences: 1
@@ -16,7 +16,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        Exclude Android: 1
+        Exclude Android: 0
         Exclude Editor: 1
         Exclude Linux64: 1
         Exclude OSXUniversal: 1
@@ -26,10 +26,11 @@ PluginImporter:
   - first:
       Android: Android
     second:
-      enabled: 0
+      enabled: 1
       settings:
         AndroidSharedLibraryType: Executable
         CPU: ARM64
+        Is16KbAligned: false
   - first:
       Any: 
     second:

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -15,7 +15,7 @@
     "com.unity.collections": "2.5.7",
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.mathematics": "1.2.6",
-    "com.unity.render-pipelines.universal": "14.0.11",
+    "com.unity.render-pipelines.universal": "14.0.12",
     "com.unity.test-framework": "1.1.33",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -47,7 +47,7 @@
       "dependencies": {}
     },
     "com.unity.burst": {
-      "version": "1.8.19",
+      "version": "1.8.21",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -100,7 +100,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
-      "version": "14.0.11",
+      "version": "14.0.12",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
@@ -111,14 +111,14 @@
       }
     },
     "com.unity.render-pipelines.universal": {
-      "version": "14.0.11",
+      "version": "14.0.12",
       "depth": 0,
       "source": "builtin",
       "dependencies": {
         "com.unity.mathematics": "1.2.1",
         "com.unity.burst": "1.8.9",
-        "com.unity.render-pipelines.core": "14.0.11",
-        "com.unity.shadergraph": "14.0.11",
+        "com.unity.render-pipelines.core": "14.0.12",
+        "com.unity.shadergraph": "14.0.12",
         "com.unity.render-pipelines.universal-config": "14.0.9"
       }
     },
@@ -138,11 +138,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.shadergraph": {
-      "version": "14.0.11",
+      "version": "14.0.12",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
-        "com.unity.render-pipelines.core": "14.0.11",
+        "com.unity.render-pipelines.core": "14.0.12",
         "com.unity.searcher": "4.9.2"
       }
     },

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.58f1
-m_EditorVersionWithRevision: 2022.3.58f1 (ed7f6eacb62e)
+m_EditorVersion: 2022.3.62f1
+m_EditorVersionWithRevision: 2022.3.62f1 (4af31df58517)


### PR DESCRIPTION
Upgraded Unity version to upgrade internal Burst dependency to the 16kb page size aligned version - `1.8.21` or later

- Refs #386

